### PR TITLE
Updated link and changed mod format to follow convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 ﻿.idea/
+\[Csharp\]\[EN\] Stardew Access/

--- a/README.md
+++ b/README.md
@@ -21,15 +21,16 @@ You can have basic pluralization setup with just fluent but that gets complicate
 1. Rename the folder `[Fluent][EN] Stardew Access` and replace `EN` with the appropriate language code.
 2. Change the `Name`, `Author`, `Description`, and `UniqueID` values to describe your mod. (Don’t change the `UniqueID` under `ContentPackFor` and `Dependencies`!)
    - The `Name` field's value should ideally be the same as the folder's name you just changed to and as such, you'll only need to replace `EN` with your language code.
-   - Follow this format for the UniqueID: `<your-name>.fluent.stardewaccess.<language-code>`
-     - An example for English translation mod would be `shoaib.fluent.stardewaccess.en`
+   - Follow this format for the UniqueID: `<YourName>.
+   Fluent.StardewAccess.<language-code>`
+     - An example of a United States English translation mod would be `Shoaib.Fluent.StardewAccess.en-us`
 3. Create a folder named `i18n` inside this folder. This will contain all the translation `.ftl` files.
 4. Now copy the `.ftl` files from the `i18n` folder of the mod's beta or release version of the mod and rename them with your language code.
 5. That's it! Now you can translate these files.
 
 You can find syntax guide for fluent [here](https://projectfluent.org/fluent/guide/).
 There's also a [playground](https://projectfluent.org/play/) where you can test things if you want to.
-You might also need to look into the custom functions added by [Project Fluent mod](https://hackmd.io/@Shockah/H1q8H-mcc/https%3A%2F%2Fhackmd.io%2F%40Shockah%2FHy8nTM7c5) and [Stardew Access](https://github.com/khanshoaib3/stardew-access/blob/c966d188ea506a70782edb5177ef6e87c685f890/stardew-access/Translation/CustomFluentFunctions.cs#L29-L91)
+You might also need to look into the custom functions added by [Project Fluent mod](https://hackmd.io/@Shockah/H1q8H-mcc/https%3A%2F%2Fhackmd.io%2F%40Shockah%2FHy8nTM7c5) and [Stardew Access](https://github.com/stardew-access/stardew-access/blob/c966d188ea506a70782edb5177ef6e87c685f890/stardew-access/Translation/CustomFluentFunctions.cs#L29-L91)
 
 <TODO Add the doc link for custom functions in stardew access.>
 


### PR DESCRIPTION
This pulll request deletes an empty directory that is currently unused according to the read me, updates a link to point to the new stardew-access/stardew-access repo, and changes the mod ID example to follow the examples set by many other popular mods of title case such as content patcher, cornucopia, UI Info Suite, etc.